### PR TITLE
[FE] 카카오 맵 포커스 레벨 관련 로직 수정

### DIFF
--- a/src/components/mypage/plans/PlanMap.svelte
+++ b/src/components/mypage/plans/PlanMap.svelte
@@ -2,6 +2,54 @@
   import { afterUpdate } from 'svelte'
   export let planDetail
 
+  let level = 2
+  let maxDistance = 0
+
+  const radians = (degrees) => {
+    return degrees * Math.PI / 180;
+  };
+
+  const calculateDistance = (lat1, lat2, lon1, lon2) => {
+    const earthRadius = 6371 // km
+    lat1 = radians(lat1)
+    lat2 = radians(lat2)
+    lon1 = radians(lon1)
+    lon2 = radians(lon2)
+
+    let distance = Math.acos(Math.sin(lat1) * Math.sin(lat2) + Math.cos(lat1) * Math.cos(lat2) * Math.cos(lon1 - lon2)) * earthRadius * 1000
+    return distance
+  }
+
+  const focusLeveling = (maxDistance) => {
+    if (maxDistance < 100) {
+      level = 2
+    } else if (maxDistance >= 100 && maxDistance < 250) {
+      level = 2
+    } else if (maxDistance >= 250 && maxDistance < 500) {
+      level = 3
+    } else if (maxDistance >= 500 && maxDistance < 1000) {
+      level = 4
+    } else if (maxDistance >= 1000 && maxDistance < 2000) {
+      level = 5
+    } else if (maxDistance >= 2000 && maxDistance < 4000) {
+      level = 7
+    } else if (maxDistance >= 4000 && maxDistance < 8000) {
+      level = 8
+    } else if (maxDistance >= 8000 && maxDistance < 16000) {
+      level = 9
+    } else if (maxDistance >= 16000 && maxDistance < 32000) {
+      level = 10
+    } else if (maxDistance >= 32000 && maxDistance < 64000) {
+      level = 11
+    } else if (maxDistance >= 64000 && maxDistance < 128000) {
+      level = 12
+    } else if (maxDistance >= 128000 && maxDistance < 200000) {
+      level = 13
+    } else if (maxDistance >= 200000) {
+      level = 14
+    }
+  }
+
   afterUpdate(() => {
     if ($planDetail.data.detailPlans.length != 0) {
 
@@ -19,11 +67,20 @@
       total_x /= positions.length
       total_y /= positions.length
 
+      for (var i = 0; i < positions.length; i++) {
+        let distance = calculateDistance(positions[i].latitude, total_y, positions[i].longitude, total_x)
+        if (distance >= maxDistance) maxDistance = distance
+      }
+
+      focusLeveling(maxDistance)
+
       var mapContainer = document.getElementById('map'),
       mapOption = { 
           center: new kakao.maps.LatLng(total_y, total_x),
-          level: 5
+          level: level
       }
+
+      maxDistance = 0
 
       // 컴포넌트 해제된 상태에서 map을 생성하려 할 경우 오류 발생하므로 분기 처리
       if (mapContainer) {

--- a/src/components/places/PlaceDetail.svelte
+++ b/src/components/places/PlaceDetail.svelte
@@ -38,6 +38,9 @@
         level: 1
     }
 
+    // 초기 업데이트 시 category_group_id가 없어서 imageSrc 관련 오류 로그가 출력되어 로그 출력 방지용으로 분기 처리
+    if (!$placeDetail.data.category_group_id) return
+
     var imageSrc = `/src/images/markers/solo-marker-${$placeDetail.data.category_group_id}.png`,   
         imageSize = new kakao.maps.Size(100, 100)
       

--- a/src/components/places/PlaceMap.svelte
+++ b/src/components/places/PlaceMap.svelte
@@ -2,6 +2,9 @@
   import { afterUpdate } from 'svelte'
   export let places
 
+  let level = 2
+  let maxDistance = 0
+
   function makeOverListener(map, marker, infowindow) {
     return function() {
         infowindow.open(map, marker);
@@ -12,6 +15,51 @@
       return function() {
           infowindow.close();
       }
+  }
+
+  const radians = (degrees) => {
+    return degrees * Math.PI / 180;
+  };
+
+  const calculateDistance = (lat1, lat2, lon1, lon2) => {
+    const earthRadius = 6371 // km
+    lat1 = radians(lat1)
+    lat2 = radians(lat2)
+    lon1 = radians(lon1)
+    lon2 = radians(lon2)
+
+    let distance = Math.acos(Math.sin(lat1) * Math.sin(lat2) + Math.cos(lat1) * Math.cos(lat2) * Math.cos(lon1 - lon2)) * earthRadius * 1000
+    return distance
+  }
+
+  const focusLeveling = (maxDistance) => {
+    if (maxDistance < 100) {
+      level = 2
+    } else if (maxDistance >= 100 && maxDistance < 250) {
+      level = 2
+    } else if (maxDistance >= 250 && maxDistance < 500) {
+      level = 3
+    } else if (maxDistance >= 500 && maxDistance < 1000) {
+      level = 4
+    } else if (maxDistance >= 1000 && maxDistance < 2000) {
+      level = 5
+    } else if (maxDistance >= 2000 && maxDistance < 4000) {
+      level = 7
+    } else if (maxDistance >= 4000 && maxDistance < 8000) {
+      level = 8
+    } else if (maxDistance >= 8000 && maxDistance < 16000) {
+      level = 9
+    } else if (maxDistance >= 16000 && maxDistance < 32000) {
+      level = 10
+    } else if (maxDistance >= 32000 && maxDistance < 64000) {
+      level = 11
+    } else if (maxDistance >= 64000 && maxDistance < 128000) {
+      level = 12
+    } else if (maxDistance >= 128000 && maxDistance < 200000) {
+      level = 13
+    } else if (maxDistance >= 200000) {
+      level = 14
+    }
   }
 
   afterUpdate(() => {
@@ -31,11 +79,20 @@
       total_x /= positions.length
       total_y /= positions.length
 
+      for (var i = 0; i < positions.length; i++) {
+        let distance = calculateDistance(positions[i].y, total_y, positions[i].x, total_x)
+        if (distance >= maxDistance) maxDistance = distance
+      }
+
+      focusLeveling(maxDistance)
+
       var mapContainer = document.getElementById('map'),
       mapOption = { 
           center: new kakao.maps.LatLng(total_y, total_x),
-          level: 7
+          level: level
       }
+
+      maxDistance = 0
 
       var map = new kakao.maps.Map(mapContainer, mapOption);
 


### PR DESCRIPTION
현재 카카오 맵 포커스 레벨이 고정되어 있으나 장소가 많아지고 장소 간 거리가 유동적일 경우 적절하게 포커싱이 되지 않는 문제가 있다. 개선이 가능하다면 포커스 레벨을 조정하는 로직을 만들어서 반영하도록 한다

* [x] 포커스 레벨 조정 로직 구상
* [x] 적용 및 테스트

This closes #71 